### PR TITLE
Allow for a typecheck test to run first

### DIFF
--- a/run
+++ b/run
@@ -109,12 +109,11 @@ jshon -Q -n object -s 'close-tab' -i 'command'
 
 
 # Compiling and running each test file.
-testfiles="$(find "$resources" -name '*_test.hs' -print0)"
-while [ -n "$testfiles" ]; do
-    testfile="${testfiles##*\0}"
-    testfiles="${testfiles%\0*}"
+for testfile in "$resources/typecheck.hs" "$resources"/*_test.hs; do
+    [ -f "$testfile" ] || continue
     testbase="$(basename "$testfile")"
-    testname="${testbase%_test.hs}"
+    testname="${testbase%.hs}"
+    testname="${testname%_test}"
     tabtitle="$(echo "$testname" | tr '_' ' ')"
 
     jshon -Q -n object -s 'start-tab' -i 'command' \


### PR DESCRIPTION
If this happens first in a separate file, we can avoid showing the
student the internals of the remainder of the tests.